### PR TITLE
fix aapt dump parse for versionName on win os

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/functions.js
+++ b/functions.js
@@ -465,12 +465,11 @@ async function getPackageInfo(apkPath) {
 
     if (`${global.platform}` == "win64" || `${global.platform}` == "win32") {
         packageStuff = await execShellCommand(`aapt dump badging "${apkPath}"`);
-        packageLine = packageStuff.match(/package: (.*)/g);
         packageName = packageStuff.match(/name='([a-zA-Z.]*)'/g);
         packageName = packageName[0].split("'")[1]
-        versionCode = packageStuff.match(/versionCode='([0-9a-zA-Z.]*)'/g);
+        versionCode = packageStuff.match(/versionCode='(\d+)'/g);
         versionCode = versionCode[0].split("'")[1]
-        versionName = packageStuff.match(/versionName='([0-9a-zA-Z.]*)'/g);
+        versionName = packageStuff.match(/versionName='([^']+)/g);
         versionName = versionName[0].split("'")[1]
         info = {packageName: packageName, versionCode: versionCode, versionName: versionName}
         return info


### PR DESCRIPTION
I tried to install a game where the `aapt dump badging` output contained `versionName='1.0.5.160981 (Release_1.0.5)'`.

The current regex doesn't parse this value correctly so the installation failed. Both the space and parenthesis are missing from the regex.

I have replaced the regex with the one already used by [node-aapt](https://github.com/vldmkr/node-aapt/blob/ba4add44f81c125633cab3c3b17d7ae10ea3b5f9/index.js#L26) in the `packageInfo` call.

I have also removed the `packageLine` line since that variable is not used anywhere.

I have also added a gitignore file for the `node_modules` folder