### PR TITLE
fix closing tag for fa icons

### DIFF
--- a/views/installed.twig
+++ b/views/installed.twig
@@ -13,12 +13,12 @@
       ipcRenderer.on('list_installed_app', (event, arg) => {
         console.log("list_installed_app msg came ! ");
         console.log(arg)
-        trstring = `<tr><td style="font-weight: bolder; font-size: large">${arg.packageName} VersionCode: ${arg.versionCode})`
+        trstring = `<tr><td style="font-weight: bolder; font-size: large">${arg.packageName} VersionCode: ${arg.versionCode}`
         if (arg.update) {
           trstring += "<a onclick='update(\""+ arg.update.path +"\")'>"
-          trstring += `<h2 class="pull-right push-right"><span class="badge badge-success badge-md"> <i class="fa fa-upload" aria-hidden="true"> Update to ${arg.update.versionCode}</span></h2></a>`
+          trstring += `<h2 class="pull-right push-right"><span class="badge badge-success badge-md"> <i class="fa fa-upload" aria-hidden="true"></i> Update to ${arg.update.versionCode}</span></h2></a>`
         } else {
-          trstring += `<a onclick="uninstall(this, '${arg.packageName}')"><h2 class="pull-right push-right"><span class="badge badge-warning badge-md"> <i id="uninstallBtn" class="fa trash" aria-hidden="true"> Uninstall</span></h2></a>`
+          trstring += `<a onclick="uninstall(this, '${arg.packageName}')"><h2 class="pull-right push-right"><span class="badge badge-warning badge-md"> <i id="uninstallBtn" class="fa fa-trash-o" aria-hidden="true"></i> Uninstall</span></h2></a>`
         }
         trstring += `<td></tr>`
         row = $("#listTable tbody").append(trstring)


### PR DESCRIPTION
In the installed app list, some fontawesome icons are missing a closing `</i>` tag which causes the icon to no show and the font of the text to break.

This MR adds those tags
