### PR TITLE
Stop caring about rclone version

### DIFF
--- a/windows-install.bat
+++ b/windows-install.bat
@@ -29,8 +29,8 @@ echo Unzipping adb
 "C:\Program Files\7-Zip\7z.exe" x -y android-tools.zip > NUL
 echo Combining folders
 SET COPYCMD=/Y
-move /y rclone-v1.55.0-windows-amd64\rclone.exe platform-tools\rclone.exe > NUL
-del /F /Q rclone-v1.55.0-windows-amd64\  > NUL
+move /y rclone-*-windows-amd64\rclone.exe platform-tools\rclone.exe > NUL
+del /F /Q rclone-*-windows-amd64\  > NUL
 echo Adding to PATH
 :: Get System PATH
 for /f "tokens=2*" %%A in ('reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v Path') do set syspath=%%B


### PR DESCRIPTION
Untested but the wildcards should match any version. Should prevent issues like #70.