### PR TITLE
Match any rclone version (but for real this time)

### DIFF
--- a/windows-install.bat
+++ b/windows-install.bat
@@ -29,8 +29,11 @@ echo Unzipping adb
 "C:\Program Files\7-Zip\7z.exe" x -y android-tools.zip > NUL
 echo Combining folders
 SET COPYCMD=/Y
-move /y rclone-v1.55.0-windows-amd64\rclone.exe platform-tools\rclone.exe > NUL
-del /F /Q rclone-v1.55.0-windows-amd64\  > NUL
+for /d %%a in (rclone-*) do (
+    move /y %%a\rclone.exe platform-tools\ > NUL
+    del /F /Q %%a > NUL
+    rmdir %%a > NUL
+)
 echo Adding to PATH
 :: Get System PATH
 for /f "tokens=2*" %%A in ('reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v Path') do set syspath=%%B


### PR DESCRIPTION
I feel pretty guilty about #76 ... sorry. `move` apparently doesn't support wildcards in folder names, just file names :(

I've tested this exact snippet in `wine` and it moves `rclone-1.55.5-windows-amd64/rclone.exe` to `platform-tools/rclone.exe`, cleaning up after itself. I haven't tested the whole script as I don't have access to a Windows machine.

Sorry for introducing bugs into your code...